### PR TITLE
fix: ERR_UNSUPPORTED_ESM_URL_SCHEME error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import chalk from 'chalk'
 import fs from 'fs'
 import path from 'path'
+import { pathToFileURL } from 'url'
 import { type Config, generateFromConfig } from './generateFromConfig'
 
 async function main() {
@@ -16,7 +17,8 @@ async function main() {
     return
   }
 
-  const config = (await import(CONFIG_PATH)).default as Config
+  const config = (await import(pathToFileURL(CONFIG_PATH).href))
+    .default as Config
 
   if (!config.url) {
     console.log(


### PR DESCRIPTION
```
> astro-boilerplate@0.0.1 prebuild
> sparing-open-api

node:internal/modules/esm/load:217
    throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(parsed, schemes);
          ^

Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'     
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:217:11)
    at defaultLoad (node:internal/modules/esm/load:109:3)
    at ModuleLoader.load (node:internal/modules/esm/loader:670:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:483:43)
    at #createModuleJob (node:internal/modules/esm/loader:507:36)
    at #getJobFromResolveResult (node:internal/modules/esm/loader:275:34)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:243:41)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:546:25) {
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
}
```

Node.js v22.12.0